### PR TITLE
Update index.ts

### DIFF
--- a/src/components/ion-digit-keyboard/components/index.ts
+++ b/src/components/ion-digit-keyboard/components/index.ts
@@ -1,1 +1,1 @@
-export { IonDigitKeyboardCmp } from './ion-digit-keyboard-cmp/ion-digit-keyboard-cmp.ts';
+export { IonDigitKeyboardCmp } from './ion-digit-keyboard-cmp/ion-digit-keyboard-cmp';


### PR DESCRIPTION
Typescript Error
An import path cannot end with a '.ts' extension. Consider importing './ion-digit-keyboard-cmp/ion-digit-keyboard-cmp' instead.